### PR TITLE
Implement tutorial and alert systems

### DIFF
--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -1,0 +1,47 @@
+use bevy::prelude::*;
+use crate::game_state::{self, GameState, ResourceType};
+
+#[derive(Resource, Default)]
+pub struct AlertState {
+    power: bool,
+    food: bool,
+    unrest: bool,
+}
+
+pub struct AlertPlugin;
+
+impl Plugin for AlertPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<AlertState>()
+            .add_systems(Update, alert_system);
+    }
+}
+
+fn alert_system(mut alert: ResMut<AlertState>, mut game_state: ResMut<GameState>, time: Res<Time>) {
+    let now = time.elapsed_seconds_f64();
+    let net_power = game_state.total_generated_power - game_state.total_consumed_power;
+    if net_power < 0.0 && !alert.power {
+        game_state::add_notification(&mut game_state.notifications, "ALERT: Power deficit detected.".to_string(), now);
+        alert.power = true;
+    } else if net_power >= 0.0 && alert.power {
+        game_state::add_notification(&mut game_state.notifications, "Power levels stabilized.".to_string(), now);
+        alert.power = false;
+    }
+
+    let food = *game_state.current_resources.get(&ResourceType::NutrientPaste).unwrap_or(&0.0);
+    if food < 10.0 && !alert.food {
+        game_state::add_notification(&mut game_state.notifications, "ALERT: Food shortage.".to_string(), now);
+        alert.food = true;
+    } else if food >= 10.0 && alert.food {
+        game_state::add_notification(&mut game_state.notifications, "Food supply restored.".to_string(), now);
+        alert.food = false;
+    }
+
+    if game_state.colony_happiness < 30.0 && !alert.unrest {
+        game_state::add_notification(&mut game_state.notifications, "ALERT: Civic unrest rising.".to_string(), now);
+        alert.unrest = true;
+    } else if game_state.colony_happiness >= 30.0 && alert.unrest {
+        game_state::add_notification(&mut game_state.notifications, "Civic order restored.".to_string(), now);
+        alert.unrest = false;
+    }
+}

--- a/src/first_hour_tooltips.rs
+++ b/src/first_hour_tooltips.rs
@@ -1,10 +1,26 @@
 // Tooltip sequence for Nexus Core tutorial (Bevy ECS-style)
 use bevy::prelude::*;
+use crate::{
+    game_state::{self, GameState, ServiceType},
+    CurrentApp, AppType,
+};
 
 #[derive(Resource)]
 pub struct TutorialState {
     pub current_step: usize,
     pub completed_steps: Vec<bool>,
+    pub active_tooltip: Option<Entity>,
+}
+
+impl Default for TutorialState {
+    fn default() -> Self {
+        let steps = get_tutorial_steps();
+        Self {
+            current_step: 0,
+            completed_steps: vec![false; steps.len()],
+            active_tooltip: None,
+        }
+    }
 }
 
 pub struct TooltipStep {
@@ -105,12 +121,188 @@ pub fn get_tutorial_steps() -> Vec<TooltipStep> {
 }
 
 // Placeholder condition helpers
-fn has_entity_with_tag(_world: &World, _tag: &str) -> bool { false }
-fn entity_has_flag(_world: &World, _entity: &str, _flag: &str) -> bool { false }
-fn entity_produces_resource(_world: &World, _entity: &str) -> bool { false }
-fn player_lacks_available_specialists(_world: &World) -> bool { false }
-fn population_increased(_world: &World) -> bool { false }
-fn happiness_below_threshold(_world: &World, _threshold: f32) -> bool { false }
-fn all_services_covered(_world: &World) -> bool { false }
-fn tech_tree_opened(_world: &World) -> bool { false }
-fn legacy_structure_unlocked(_world: &World) -> bool { false }
+fn has_entity_with_tag(world: &World, tag: &str) -> bool {
+    let gs = world.resource::<GameState>();
+    match tag {
+        "operations_hub" => gs.administrative_spire.is_some(),
+        "extractor" => !gs.extractors.is_empty(),
+        "bio_dome" => !gs.bio_domes.is_empty(),
+        "research_institute" => !gs.research_institutes.is_empty(),
+        _ => false,
+    }
+}
+
+fn entity_has_flag(world: &World, entity: &str, flag: &str) -> bool {
+    let gs = world.resource::<GameState>();
+    if entity == "extractor" && flag == "needs_power" {
+        !gs.extractors.is_empty()
+            && (gs.total_generated_power - gs.total_consumed_power) < 0.0
+    } else {
+        false
+    }
+}
+
+fn entity_produces_resource(world: &World, entity: &str) -> bool {
+    let gs = world.resource::<GameState>();
+    if entity == "extractor" {
+        gs.extractors.iter().any(|e| e.is_staffed)
+    } else {
+        false
+    }
+}
+
+fn player_lacks_available_specialists(world: &World) -> bool {
+    let gs = world.resource::<GameState>();
+    gs.assigned_workforce >= gs.total_inhabitants
+}
+
+fn population_increased(world: &World) -> bool {
+    let gs = world.resource::<GameState>();
+    gs.total_inhabitants > 5
+}
+
+fn happiness_below_threshold(world: &World, threshold: f32) -> bool {
+    let gs = world.resource::<GameState>();
+    gs.colony_happiness < threshold
+}
+
+fn all_services_covered(world: &World) -> bool {
+    let gs = world.resource::<GameState>();
+    [ServiceType::Wellness, ServiceType::Security]
+        .iter()
+        .all(|t| gs.service_buildings.iter().any(|b| b.service_type == *t))
+}
+
+fn tech_tree_opened(world: &World) -> bool {
+    let app = world.resource::<CurrentApp>();
+    app.0 == AppType::Research
+}
+
+fn legacy_structure_unlocked(world: &World) -> bool {
+    let gs = world.resource::<GameState>();
+    gs.legacy_structure.is_some()
+}
+
+// --- Tutorial Plugin Implementation ---
+
+#[derive(Component)]
+struct TutorialTooltip;
+
+#[derive(Component)]
+struct TutorialOkButton;
+
+pub struct TutorialPlugin;
+
+impl Plugin for TutorialPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<TutorialState>()
+            .add_systems(Update, (check_tutorial_triggers_system, tooltip_button_system));
+    }
+}
+
+fn check_tutorial_triggers_system(mut commands: Commands, mut state: ResMut<TutorialState>) {
+    let steps = get_tutorial_steps();
+    if state.current_step >= steps.len() {
+        return;
+    }
+
+    let step = &steps[state.current_step];
+    if (step.trigger)(&commands.world) && state.active_tooltip.is_none() {
+        let tooltip = spawn_tooltip(&mut commands, step);
+        state.active_tooltip = Some(tooltip);
+        state.completed_steps[state.current_step] = true;
+    }
+    if state.active_tooltip.is_some() {
+        // update timestamp maybe? ignoring for now
+    } else if state.completed_steps[state.current_step] {
+        state.current_step += 1;
+    }
+}
+
+fn spawn_tooltip(commands: &mut Commands, step: &TooltipStep) -> Entity {
+    commands
+        .spawn((
+            NodeBundle {
+                style: Style {
+                    position_type: PositionType::Absolute,
+                    bottom: Val::Px(20.0),
+                    left: Val::Px(20.0),
+                    padding: UiRect::all(Val::Px(10.0)),
+                    border: UiRect::all(Val::Px(1.0)),
+                    flex_direction: FlexDirection::Column,
+                    ..default()
+                },
+                background_color: Color::rgba(0.0, 0.0, 0.2, 0.8).into(),
+                border_color: Color::CYAN.into(),
+                ..default()
+            },
+            TutorialTooltip,
+        ))
+        .with_children(|parent| {
+            parent.spawn(TextBundle::from_section(
+                step.title,
+                TextStyle {
+                    font_size: 18.0,
+                    color: Color::WHITE,
+                    ..default()
+                },
+            ));
+            parent.spawn(TextBundle::from_section(
+                step.content,
+                TextStyle {
+                    font_size: 14.0,
+                    color: Color::WHITE,
+                    ..default()
+                },
+            ));
+            if let Some(highlight) = step.ui_highlight {
+                parent.spawn(TextBundle::from_section(
+                    format!("Hint: {}", highlight),
+                    TextStyle {
+                        font_size: 12.0,
+                        color: Color::YELLOW,
+                        ..default()
+                    },
+                ));
+            }
+            parent
+                .spawn((
+                    ButtonBundle {
+                        style: Style {
+                            margin: UiRect::top(Val::Px(5.0)),
+                            padding: UiRect::all(Val::Px(5.0)),
+                            ..default()
+                        },
+                        background_color: Color::DARK_GRAY.into(),
+                        ..default()
+                    },
+                    TutorialOkButton,
+                ))
+                .with_children(|btn| {
+                    btn.spawn(TextBundle::from_section(
+                        "OK",
+                        TextStyle {
+                            font_size: 14.0,
+                            color: Color::WHITE,
+                            ..default()
+                        },
+                    ));
+                });
+        })
+        .id()
+}
+
+fn tooltip_button_system(
+    mut commands: Commands,
+    mut interaction_q: Query<(&Interaction, Entity), (Changed<Interaction>, With<TutorialOkButton>)>,
+    mut state: ResMut<TutorialState>,
+) {
+    for (interaction, entity) in &mut interaction_q {
+        if *interaction == Interaction::Pressed {
+            if let Some(root) = state.active_tooltip.take() {
+                commands.entity(root).despawn_recursive();
+            }
+            state.current_step += 1;
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,12 @@ use game_state::{
     ALL_BUILDING_TYPES,
 };
 use std::collections::HashMap;
+use first_hour_tooltips::TutorialPlugin;
+use alerts::AlertPlugin;
 
 mod game_state;
+mod first_hour_tooltips;
+mod alerts;
 use game_state::{BuildingType as GameBuildingType, DevelopmentPhase, ServiceType, ZoneType};
 
 // --- Color & Style Constants ---
@@ -204,6 +208,8 @@ fn main() {
             }),
             game_state::GameLogicPlugin,
             UiPlugin,
+            TutorialPlugin,
+            AlertPlugin,
         ))
         .insert_resource(Time::<Fixed>::from_seconds(1.0))
         .run();


### PR DESCRIPTION
## Summary
- wire up tutorial tooltip system
- add triggers for tutorial steps using game state checks
- display tutorial popups with highlight hints and dismiss button
- create an alert system that warns about power, food, and happiness
- register new TutorialPlugin and AlertPlugin

## Testing
- `cargo check` *(fails: `alsa-sys` crate requires system library)*

------
https://chatgpt.com/codex/tasks/task_e_684b54d7fa9c832e91da7d1e27ea86d7