### PR TITLE
Implement Display for Tech

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -497,6 +498,20 @@ pub enum Tech {
     IndustrialProcessing,
     ZoningOrdinances,
     ArcologyConstruction,
+}
+
+impl fmt::Display for Tech {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Tech::BasicConstructionProtocols => "Basic Construction Protocols",
+            Tech::EfficientExtraction => "Efficient Extraction",
+            Tech::AdvancedFabrication => "Advanced Fabrication",
+            Tech::IndustrialProcessing => "Industrial Processing",
+            Tech::ZoningOrdinances => "Zoning Ordinances",
+            Tech::ArcologyConstruction => "Arcology Construction",
+        };
+        write!(f, "{}", name)
+    }
 }
 
 // --- Data-Driven Building Structs ---

--- a/src/ui/research.rs
+++ b/src/ui/research.rs
@@ -105,7 +105,7 @@ pub(super) fn update_research_panel_system(
             for tech in all_techs {
                 if !game_state.unlocked_techs.contains(&tech) {
                      parent.spawn((ButtonBundle{ style: Style { width: Val::Percent(100.0), padding: UiRect::all(Val::Px(8.0)), margin: UiRect::bottom(Val::Px(4.0)), ..default() }, background_color: NORMAL_BUTTON.into(), ..default()}, ResearchItemButton(tech)))
-                     .with_children(|b| {b.spawn(TextBundle::from_section(format!("{:?}", tech), TextStyle { color: PRIMARY_TEXT_COLOR, ..default() }));});
+                     .with_children(|b| {b.spawn(TextBundle::from_section(tech.to_string(), TextStyle { color: PRIMARY_TEXT_COLOR, ..default() }));});
                 }
             }
         });
@@ -142,7 +142,7 @@ pub(super) fn update_research_details_panel_system(
             let (progress, active) = game_state.research_progress.as_ref().map(|(t,p)| (*p as u32, Some(*t))).unwrap_or((0,None));
             commands.entity(panel).with_children(|parent| {
                 parent.spawn(TextBundle::from_section(
-                    format!("{:?}", tech),
+                    tech.to_string(),
                     TextStyle { font_size: 22.0, color: PRIMARY_TEXT_COLOR, ..default() },
                 ));
                 parent.spawn(TextBundle::from_section(


### PR DESCRIPTION
## Summary
- implement `fmt::Display` for `Tech` so it has readable names
- display tech names in UI using `tech.to_string()`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68507515a508832e9b319f08b5f7862e